### PR TITLE
fix ignore_above parameter not work bug

### DIFF
--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -99,7 +99,9 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
                 @Override
                 protected String parseSourceValue(Object value) {
                     String keywordValue = value.toString();
-                    if (keywordValue.length() > ignoreAbove) {
+                    // changed character length verification to byte array length verification.
+                    // consistent with Lucene
+                    if (keywordValue.getBytes().length > ignoreAbove) {
                         return null;
                     }
                     return keywordValue;
@@ -527,7 +529,9 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
             return;
         }
 
-        if (value.length() > ignoreAbove) {
+        // changed character length verification to byte array length verification.
+        // consistent with Lucene
+        if (value.getBytes().length > ignoreAbove) {
             context.addIgnoredField(name());
             return;
         }

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
@@ -283,6 +283,24 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertEquals("field", fields[0].stringValue());
     }
 
+    public void testNewIgnoreAbove() throws IOException {
+        String test = "";
+        while (test.getBytes().length <= 32765) {
+            test = test + "￥";
+        }
+        //The string length is less than 32766, and the byte array length is greater than 32766.
+        assertNotEquals(test.length(), test.getBytes().length);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("ignore_above", 32765)));
+        String finalTest = test;
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", finalTest)));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+
+        fields = doc.rootDoc().getFields("_ignored");
+        assertEquals(1, fields.length);
+        assertEquals("field", fields[0].stringValue());
+    }
+
     public void testUpdateIgnoreAbove() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         merge(mapperService, fieldMapping(b -> b.field("type", FIELD_TYPE).field("ignore_above", 5)));

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
@@ -285,7 +285,7 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
 
     public void testNewIgnoreAbove() throws IOException {
         String test = "";
-        while (test.getBytes().length <= 32765) {
+        while (test.getBytes().length <= 32766) {
             test = test + "￥";
         }
         //The string length is less than 32766, and the byte array length is greater than 32766.

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -29,10 +29,12 @@ import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton.AUTOMATON_TYPE;
 import org.apache.lucene.util.automaton.MinimizationOperations;
 import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -40,6 +42,7 @@ import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.StringFieldScript;
+import org.elasticsearch.script.field.KeywordDocValuesField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -49,6 +52,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -69,6 +73,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             FIELD_TYPE.freeze();
         }
+
+        public static final int IGNORE_ABOVE = Integer.MAX_VALUE;
     }
 
     public static class KeywordField extends Field {
@@ -102,7 +108,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             "ignore_above",
             true,
             m -> toType(m).ignoreAbove,
-            Integer.MAX_VALUE
+            Defaults.IGNORE_ABOVE
         );
 
         private final Parameter<String> indexOptions = Parameter.restrictedStringParam(
@@ -397,7 +403,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
             failIfNoDocValues();
-            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD);
+            return new SortedSetOrdinalsIndexFieldData.Builder(
+                name(),
+                CoreValuesSourceType.KEYWORD,
+                (dv, n) -> new KeywordDocValuesField(FieldData.toString(dv), n)
+            );
         }
 
         @Override
@@ -412,7 +422,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 @Override
                 protected String parseSourceValue(Object value) {
                     String keywordValue = value.toString();
-                    // changed character length verification to character array length verification.
+                    // changed character length verification to byte array length verification.
                     // consistent with Lucene
                     if (keywordValue.getBytes().length > ignoreAbove) {
                         return null;
@@ -505,9 +515,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
     }
 
-    /** The maximum keyword length allowed for a dimension field */
-    private static final int DIMENSION_MAX_BYTES = 1024;
-
     private final boolean indexed;
     private final boolean hasDocValues;
     private final String nullValue;
@@ -589,12 +596,11 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     private void indexValue(DocumentParserContext context, String value) {
-
         if (value == null) {
             return;
         }
 
-        // changed string length verification to byte array length verification.
+        // changed character length verification to byte array length verification.
         // consistent with Lucene
         if (value.getBytes().length > ignoreAbove) {
             context.addIgnoredField(name());
@@ -602,27 +608,20 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         value = normalizeValue(fieldType().normalizer(), name(), value);
+        if (dimension) {
+            // Encode the tsid part of the dimension field. Although, it would seem reasonable
+            // to skip the encode part if we don't generate a _tsid field (as we do with number
+            // and ip fields), we keep this test because we must ensure that the value of this
+            // dimension field is not larger than TimeSeriesIdFieldMapper.DIMENSION_VALUE_LIMIT
+            BytesReference bytes = TimeSeriesIdFieldMapper.encodeTsidValue(value);
+            context.doc().addDimensionBytes(fieldType().name(), bytes);
+        }
 
         // convert to utf8 only once before feeding postings/dv/stored fields
         final BytesRef binaryValue = new BytesRef(value);
-        if (dimension && binaryValue.length > DIMENSION_MAX_BYTES) {
-            throw new IllegalArgumentException(
-                "Dimension field [" + fieldType().name() + "] cannot be more than [" + DIMENSION_MAX_BYTES + "] bytes long."
-            );
-        }
         if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
             Field field = new KeywordField(fieldType().name(), binaryValue, fieldType);
-            if (dimension) {
-                // Check that a dimension field is single-valued and not an array
-                if (context.doc().getByKey(fieldType().name()) != null) {
-                    throw new IllegalArgumentException("Dimension field [" + fieldType().name() + "] cannot be a multi-valued field.");
-                }
-                // Add dimension field with key so that we ensure it is single-valued.
-                // Dimension fields are always indexed.
-                context.doc().addWithKey(fieldType().name(), field);
-            } else {
-                context.doc().add(field);
-            }
+            context.doc().add(field);
 
             if (fieldType().hasDocValues() == false && fieldType.omitNorms()) {
                 context.addToFieldNames(fieldType().name());
@@ -642,25 +641,17 @@ public final class KeywordFieldMapper extends FieldMapper {
             final CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
             ts.reset();
             if (ts.incrementToken() == false) {
-                throw new IllegalStateException(
-                    "The normalization token stream is "
-                        + "expected to produce exactly 1 token, but got 0 for analyzer "
-                        + normalizer
-                        + " and input \""
-                        + value
-                        + "\""
-                );
+                throw new IllegalStateException(String.format(Locale.ROOT, """
+                    The normalization token stream is expected to produce exactly 1 token, \
+                    but got 0 for analyzer %s and input "%s"
+                    """, normalizer, value));
             }
             final String newValue = termAtt.toString();
             if (ts.incrementToken()) {
-                throw new IllegalStateException(
-                    "The normalization token stream is "
-                        + "expected to produce exactly 1 token, but got 2+ for analyzer "
-                        + normalizer
-                        + " and input \""
-                        + value
-                        + "\""
-                );
+                throw new IllegalStateException(String.format(Locale.ROOT, """
+                    The normalization token stream is expected to produce exactly 1 token, \
+                    but got 2+ for analyzer %s and input "%s"
+                    """, normalizer, value));
             }
             ts.end();
             return newValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
@@ -121,7 +121,9 @@ class FlattenedFieldParser {
     }
 
     private void addField(ContentPath path, String currentName, String value, List<IndexableField> fields) {
-        if (value.length() > ignoreAbove) {
+        // changed character length verification to byte array length verification.
+        // consistent with Lucene
+        if (value.getBytes().length > ignoreAbove) {
             return;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -232,7 +232,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
     public void testNewIgnoreAbove() throws IOException {
         String test = "";
-        while (test.getBytes().length <= 32765) {
+        while (test.getBytes().length <= 32766) {
             test = test + "￥";
         }
         //The string length is less than 32766, and the byte array length is greater than 32766.

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -230,6 +230,24 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertEquals("field", fields[0].stringValue());
     }
 
+    public void testNewIgnoreAbove() throws IOException {
+        String test = "";
+        while (test.getBytes().length <= 32765) {
+            test = test + "￥";
+        }
+        //The string length is less than 32766, and the byte array length is greater than 32766.
+        assertNotEquals(test.length(), test.getBytes().length);
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "keyword").field("ignore_above", 32765)));
+        String finalTest = test;
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", finalTest)));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+
+        fields = doc.rootDoc().getFields("_ignored");
+        assertEquals(1, fields.length);
+        assertEquals("field", fields[0].stringValue());
+    }
+
     public void testNullValue() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
@@ -322,6 +322,28 @@ public class FlattenedFieldParserTests extends ESTestCase {
         assertEquals(0, fields.size());
     }
 
+    public void testNewIgnoreAbove() throws IOException {
+        String test = "";
+        while (test.getBytes().length <= 32765) {
+            test = test + "￥";
+        }
+        //The string length is less than 32766, and the byte array length is greater than 32766.
+        assertNotEquals(test.length(), test.getBytes().length);
+        String input = "{ \"key\": \"" + test + "\" }";
+        XContentParser xContentParser = createXContentParser(input);
+        FlattenedFieldParser configuredParser = new FlattenedFieldParser(
+            "field",
+            "field._keyed",
+            new FakeFieldType("field"),
+            Integer.MAX_VALUE,
+            32765,
+            null
+        );
+
+        List<IndexableField> fields = configuredParser.parse(xContentParser);
+        assertEquals(0, fields.size());
+    }
+
     public void testNullValues() throws Exception {
         String input = "{ \"key\": null}";
         XContentParser xContentParser = createXContentParser(input);

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
@@ -324,7 +324,7 @@ public class FlattenedFieldParserTests extends ESTestCase {
 
     public void testNewIgnoreAbove() throws IOException {
         String test = "";
-        while (test.getBytes().length <= 32765) {
+        while (test.getBytes().length <= 32766) {
             test = test + "￥";
         }
         //The string length is less than 32766, and the byte array length is greater than 32766.


### PR DESCRIPTION
For keyword and flattened fields, if the value of ignore_above is close to the limit value(32766 ), the parameter may not take effect and the Lucene exception is thrown.

This is because the lengths of strings and byte arrays in different languages in Java are inconsistent.

For Chinese characters, the length of a single character string must be 2 less than the length of the byte array of a single character.

Therefore, if the ignore_above attribute is set to close to the maximum value when Chinese characters are stored in keyword field, the ignore_above attribute may not take effect. As a result, the document fails to be inserted.

so i changed character length verification to byte array length verification, consistent with Lucene.

Fixes #82083